### PR TITLE
Update default resource to work without O365

### DIFF
--- a/AzureAD-OAuth-Demo/App_Start/Startup.Auth.cs
+++ b/AzureAD-OAuth-Demo/App_Start/Startup.Auth.cs
@@ -70,7 +70,7 @@ namespace AzureAD_OAuth_Demo
                 ClientSecret = "",
                 Provider = new AzureADAuthenticationProvider()
             };
-            azureAdOptions.Resource.Add("https://outlook.office365.com/");
+            azureAdOptions.Resource.Add("https://graph.windows.net/");
             app.UseAzureADAuthentication(azureAdOptions);
         }
     }


### PR DESCRIPTION
Default resource "https://outlook.office365.com/" doesn't work if there isn't an Office 365 subscription attached to the Azure AD tenant, and causes unexpected behavior when running the demo app. Recommend "https://graph.windows.net/" instead